### PR TITLE
Minor enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var Transform = require('stream').Transform;
 var inherits = require('inherits');
 
-var Volume = function(volume) {
+function Volume (volume) {
+  if (!(this instanceof Volume)) return new Volume(value);
+  
   if (volume === undefined) volume = 1;
   this.setVolume(volume);
   Transform.call(this);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var Transform = require('stream').Transform;
-var util = require('util');
+var inherits = require('inherits');
 
 var Volume = function() {
   this.setVolume(1.0);
   Transform.call(this);
 };
-util.inherits(Volume, Transform);
+inherits(Volume, Transform);
 
 Volume.prototype.setVolume = function(volume) {
   this.volume = volume;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 var Transform = require('stream').Transform;
 var inherits = require('inherits');
 
-var Volume = function() {
-  this.setVolume(1.0);
+var Volume = function(volume) {
+  if (volume === undefined) volume = 1;
+  this.setVolume(volume);
   Transform.call(this);
 };
 inherits(Volume, Transform);

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/reneraab/pcm-volume/issues"
   },
+  "dependencies": {
+    "inherits": "^2.0.1"
+  },
   "homepage": "https://github.com/reneraab/pcm-volume"
 }


### PR DESCRIPTION
`util` is replaced with [`inherits`](https://www.npmjs.com/package/inherits) - this makes for minimal bundled code for browserify, as util is quite extensive package. That’s a good practice.
Also now it is able to pass volume to constructor, which is useful for piping.

@reneraab please, consider)

Also I invite you to add this module to [audio-lab](https://github.com/audio-lab) project if you want, it will fit just nice there!)
