### PR TITLE
Add license field to package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
   "dependencies": {
     "inherits": "^2.0.1"
   },
-  "homepage": "https://github.com/reneraab/pcm-volume"
+  "homepage": "https://github.com/reneraab/pcm-volume",
+  "license" : "MIT"
 }


### PR DESCRIPTION
Adds license field to the package.json file so that the published package on NPM will list MIT as the license instead of "None", requiring a click through to the GH repo to confirm its license status.

Signed-off-by: Matthew Peveler <matt.peveler@gmail.com>